### PR TITLE
Align ApiService with implemented backend routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Blake
+
+## API
+
+Current API endpoints:
+
+- `POST /auth/signup` – register a new user.
+- `POST /auth/login` – log in and receive a token.
+- `POST /auth/logout` – log out the current user.
+- `GET /user/profile` – retrieve the authenticated user profile.
+- `GET /market/prices/{symbol}` – get market prices for a symbol.
+- `GET /market/orderbook/{symbol}` – get order book data for a symbol.
+
+The client `ApiService` and the FastAPI backend only support these routes.

--- a/main.py
+++ b/main.py
@@ -68,11 +68,28 @@ async def login(email: str, password: str):
             detail=str(e)
         )
 
+@app.post("/auth/logout")
+async def logout():
+    try:
+        supabase.auth.sign_out()
+        return {"message": "Logged out successfully"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
 # Routes protégées
 @app.get("/user/profile")
-async def get_profile(current_user = Depends(get_current_user)):
+async def get_profile(current_user=Depends(get_current_user)):
     try:
-        profile = supabase.from_('profiles').select('*').eq('id', current_user.id).single().execute()
+        profile = (
+            supabase.from_("profiles")
+            .select("*")
+            .eq("id", current_user.id)
+            .single()
+            .execute()
+        )
         return profile
     except Exception as e:
         raise HTTPException(
@@ -82,13 +99,13 @@ async def get_profile(current_user = Depends(get_current_user)):
 
 # Routes pour les données de trading
 @app.get("/market/prices/{symbol}")
-async def get_market_prices(symbol: str, current_user = Depends(get_current_user)):
+async def get_market_prices(symbol: str, current_user=Depends(get_current_user)):
     # Implémentation pour récupérer les prix du marché
     pass
 
 @app.get("/market/orderbook/{symbol}")
-async def get_orderbook(symbol: str, current_user = Depends(get_current_user)):
+async def get_orderbook(symbol: str, current_user=Depends(get_current_user)):
     # Implémentation pour récupérer le carnet d'ordres
     pass
 
-# Plus de routes à venir... 
+# Plus de routes à venir...

--- a/services/api.js
+++ b/services/api.js
@@ -21,7 +21,7 @@ class ApiService {
         endpoint,
         method,
         data,
-        headers: this.token ? { Authorization: `Bearer ${this.token}` } : {}
+        headers: this.token ? { Authorization: `Bearer ${this.token}` } : {},
       });
 
       return response;
@@ -31,7 +31,7 @@ class ApiService {
     }
   }
 
-  // Authentification
+  // Authentication
   async login(email, password) {
     const response = await this.request('/auth/login', 'POST', { email, password });
     if (response.data?.access_token) {
@@ -49,16 +49,12 @@ class ApiService {
     return await this.request('/auth/logout', 'POST');
   }
 
-  // Profil utilisateur
+  // User profile
   async getUserProfile() {
     return await this.request('/user/profile');
   }
 
-  async updateUserProfile(data) {
-    return await this.request('/user/profile', 'PUT', data);
-  }
-
-  // Données de marché
+  // Market data
   async getMarketPrices(symbol) {
     return await this.request(`/market/prices/${symbol}`);
   }
@@ -66,86 +62,7 @@ class ApiService {
   async getOrderBook(symbol) {
     return await this.request(`/market/orderbook/${symbol}`);
   }
-
-  // Trading
-  async placeOrder(orderData) {
-    return await this.request('/trading/order', 'POST', orderData);
-  }
-
-  async cancelOrder(orderId) {
-    return await this.request(`/trading/order/${orderId}`, 'DELETE');
-  }
-
-  async getOpenOrders() {
-    return await this.request('/trading/orders/open');
-  }
-
-  async getOrderHistory() {
-    return await this.request('/trading/orders/history');
-  }
-
-  // Positions
-  async getOpenPositions() {
-    return await this.request('/trading/positions');
-  }
-
-  async closePosition(positionId) {
-    return await this.request(`/trading/position/${positionId}/close`, 'POST');
-  }
-
-  // Analyse
-  async getPerformanceMetrics() {
-    return await this.request('/analysis/performance');
-  }
-
-  async getSentimentData(symbol) {
-    return await this.request(`/analysis/sentiment/${symbol}`);
-  }
-
-  // Screener
-  async runScreener(filters) {
-    return await this.request('/screener/run', 'POST', filters);
-  }
-
-  async getSavedScreeners() {
-    return await this.request('/screener/saved');
-  }
-
-  async saveScreener(screenerData) {
-    return await this.request('/screener/save', 'POST', screenerData);
-  }
-
-  // Backtesting
-  async runBacktest(config) {
-    return await this.request('/backtest/run', 'POST', config);
-  }
-
-  async getBacktestHistory() {
-    return await this.request('/backtest/history');
-  }
-
-  // Watchlist
-  async getWatchlist() {
-    return await this.request('/watchlist');
-  }
-
-  async addToWatchlist(symbol) {
-    return await this.request('/watchlist/add', 'POST', { symbol });
-  }
-
-  async removeFromWatchlist(symbol) {
-    return await this.request(`/watchlist/remove/${symbol}`, 'DELETE');
-  }
-
-  // Notifications
-  async getNotifications() {
-    return await this.request('/notifications');
-  }
-
-  async markNotificationAsRead(notificationId) {
-    return await this.request(`/notifications/${notificationId}/read`, 'POST');
-  }
 }
 
 export const api = new ApiService();
-export default api; 
+export default api;

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "dummy")
+
+from main import app
+
+
+def _get_paths():
+    return set(app.openapi()["paths"].keys())
+
+
+def test_available_endpoints():
+    paths = _get_paths()
+    expected = {
+        "/auth/signup",
+        "/auth/login",
+        "/auth/logout",
+        "/user/profile",
+        "/market/prices/{symbol}",
+        "/market/orderbook/{symbol}",
+    }
+    assert expected.issubset(paths)
+
+
+def test_trading_endpoints_absent():
+    paths = _get_paths()
+    unexpected = [
+        "/trading/order",
+        "/trading/orders/open",
+        "/trading/orders/history",
+        "/trading/positions",
+        "/trading/position/{positionId}/close",
+    ]
+    for path in unexpected:
+        assert path not in paths


### PR DESCRIPTION
## Summary
- remove unused trading, analysis, screener, backtest, watchlist and notification methods from ApiService
- implement `/auth/logout` and document supported endpoints
- add tests asserting only supported routes are exposed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689ebb7eeda08330bb441f4c6fb484bf